### PR TITLE
[Feat] 유저 온보딩 및 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,6 @@ dependencies {
 
     implementation "org.springframework.boot:spring-boot-starter-data-mongodb"
 
-    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
-
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     testImplementation 'com.h2database:h2'
@@ -54,6 +52,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // Test Containers
     testImplementation 'org.testcontainers:testcontainers:1.21.3'

--- a/src/main/java/com/lion/be/LionChatBeApplication.java
+++ b/src/main/java/com/lion/be/LionChatBeApplication.java
@@ -2,7 +2,9 @@ package com.lion.be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class LionChatBeApplication {
 

--- a/src/main/java/com/lion/be/auth/controller/dto/CurrentUserResponse.java
+++ b/src/main/java/com/lion/be/auth/controller/dto/CurrentUserResponse.java
@@ -1,6 +1,5 @@
 package com.lion.be.auth.controller.dto;
 
-import lombok.Builder;
 
 public record CurrentUserResponse(Long id, String email, String name, String imageUrl) {
 

--- a/src/main/java/com/lion/be/global/controller/ExceptionController.java
+++ b/src/main/java/com/lion/be/global/controller/ExceptionController.java
@@ -1,0 +1,41 @@
+package com.lion.be.global.controller;
+
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.lion.be.global.controller.dto.ErrorResponse;
+import com.lion.be.global.exception.BaseException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionController {
+
+	@ExceptionHandler(BaseException.class)
+	public ResponseEntity<ErrorResponse> exceptionHandler(BaseException e) {
+		log.error(">>>>> [ERROR] {}, {}", e.getStatusCode(), e.getMessage());
+		int statusCode = e.getStatusCode();
+
+		ErrorResponse body = ErrorResponse.builder()
+			.code(String.valueOf(e.getStatusCode()))
+			.message(e.getMessage())
+			.build();
+
+		return ResponseEntity.status(statusCode).body(body);
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
+		log.error(">>>>> [ERROR] {}, {}", 400, e.getMessage());
+		ErrorResponse body = ErrorResponse.builder()
+			.code("400")
+			.message(e.getFieldError().getDefaultMessage())
+			.build();
+
+		return ResponseEntity.badRequest().body(body);
+	}
+}

--- a/src/main/java/com/lion/be/global/controller/dto/ErrorResponse.java
+++ b/src/main/java/com/lion/be/global/controller/dto/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.lion.be.global.controller.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class ErrorResponse {
+	String code;
+	String message;
+}

--- a/src/main/java/com/lion/be/global/controller/dto/SuccessResponse.java
+++ b/src/main/java/com/lion/be/global/controller/dto/SuccessResponse.java
@@ -1,0 +1,16 @@
+package com.lion.be.global.controller.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
+import lombok.Value;
+
+@JsonInclude(JsonInclude.Include.NON_NULL) // null인 필드
+@Value
+@Builder
+public class SuccessResponse<T> {
+
+	String code;
+	String message;
+	T data;
+}

--- a/src/main/java/com/lion/be/global/entity/BaseEntity.java
+++ b/src/main/java/com/lion/be/global/entity/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.lion.be.global.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+	@CreatedDate
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(nullable = false)
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/lion/be/global/exception/BaseException.java
+++ b/src/main/java/com/lion/be/global/exception/BaseException.java
@@ -1,0 +1,17 @@
+package com.lion.be.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BaseException extends RuntimeException {
+
+	protected BaseException(String message) {
+		super(message);
+	}
+
+	protected BaseException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public abstract int getStatusCode();
+}

--- a/src/main/java/com/lion/be/global/exception/OnboardingNotCompletedException.java
+++ b/src/main/java/com/lion/be/global/exception/OnboardingNotCompletedException.java
@@ -1,0 +1,18 @@
+package com.lion.be.global.exception;
+
+public class OnboardingNotCompletedException extends BaseException {
+  private static final String MESSAGE = "온보딩을 완료해야 해당 기능을 사용할 수 있습니다.";
+
+  public OnboardingNotCompletedException() {
+    super(MESSAGE);
+  }
+
+  public OnboardingNotCompletedException(String message) {
+    super(message);
+  }
+
+  @Override
+  public int getStatusCode() {
+    return 400;
+  }
+}

--- a/src/main/java/com/lion/be/global/exception/UserNotFoundException.java
+++ b/src/main/java/com/lion/be/global/exception/UserNotFoundException.java
@@ -1,0 +1,15 @@
+package com.lion.be.global.exception;
+
+public class UserNotFoundException extends BaseException {
+	private static final String MESSAGE = "존재하지 않는 회원입니다.";
+
+	public UserNotFoundException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return 404;
+	}
+
+}

--- a/src/main/java/com/lion/be/user/controller/UserCardController.java
+++ b/src/main/java/com/lion/be/user/controller/UserCardController.java
@@ -1,0 +1,43 @@
+package com.lion.be.user.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.lion.be.auth.domain.UserPrincipal;
+import com.lion.be.user.controller.dto.UserCardFilterRequest;
+import com.lion.be.user.controller.dto.UserCardResponse;
+import com.lion.be.user.service.UserReadService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/user/card")
+@RequiredArgsConstructor
+public class UserCardController {
+
+	private final UserReadService userReadService;
+
+	@GetMapping
+	public ResponseEntity<List<UserCardResponse>> getMatchingCards(
+		@AuthenticationPrincipal UserPrincipal userPrincipal,
+		@ModelAttribute UserCardFilterRequest request
+		){
+		log.info("사용자 {}가 카드 조회 요청 - page: {}, size: {}",
+			userPrincipal.getId(), request.getPage(), request.getSize());
+
+		List<UserCardResponse> cards = userReadService.getMatchingCards(
+			userPrincipal.getId(),
+			request
+		);
+		return ResponseEntity.ok(cards);
+	}
+
+}

--- a/src/main/java/com/lion/be/user/controller/UserCardController.java
+++ b/src/main/java/com/lion/be/user/controller/UserCardController.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.lion.be.auth.domain.UserPrincipal;
@@ -28,14 +29,19 @@ public class UserCardController {
 	@GetMapping
 	public ResponseEntity<List<UserCardResponse>> getMatchingCards(
 		@AuthenticationPrincipal UserPrincipal userPrincipal,
-		@ModelAttribute UserCardFilterRequest request
-		){
-		log.info("사용자 {}가 카드 조회 요청 - page: {}, size: {}",
-			userPrincipal.getId(), request.getPage(), request.getSize());
+		@ModelAttribute UserCardFilterRequest filterRequest,
+		@RequestParam(defaultValue = "10") int size,
+		@RequestParam(required = false) List<Long> excludeUserIds
+	) {
+		log.info("사용자 {}가 카드 조회 요청 - size: {}, 제외할 사용자 수: {}",
+			userPrincipal.getId(), size,
+			excludeUserIds != null ? excludeUserIds.size() : 0);
 
 		List<UserCardResponse> cards = userReadService.getMatchingCards(
 			userPrincipal.getId(),
-			request
+			filterRequest,
+			size,
+			excludeUserIds
 		);
 		return ResponseEntity.ok(cards);
 	}

--- a/src/main/java/com/lion/be/user/controller/UserController.java
+++ b/src/main/java/com/lion/be/user/controller/UserController.java
@@ -1,0 +1,35 @@
+package com.lion.be.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.lion.be.auth.domain.UserPrincipal;
+import com.lion.be.user.controller.dto.OnboardingRequest;
+import com.lion.be.user.controller.dto.OnboardingResponse;
+import com.lion.be.user.service.UserWriteService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/user/")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserWriteService userWriteService;
+
+	@PatchMapping("/onboarding")
+	public ResponseEntity<OnboardingResponse> onboarding (
+		@AuthenticationPrincipal UserPrincipal userPrincipal,
+		@Valid @RequestBody OnboardingRequest onboardingRequest
+	) {
+		OnboardingResponse response = userWriteService.completeUserOnboarding(
+			userPrincipal.getId(),
+			onboardingRequest
+		);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/com/lion/be/user/controller/dto/OnboardingRequest.java
+++ b/src/main/java/com/lion/be/user/controller/dto/OnboardingRequest.java
@@ -1,0 +1,35 @@
+package com.lion.be.user.controller.dto;
+
+import java.util.List;
+
+import com.lion.be.user.domain.Gender;
+import com.lion.be.user.domain.Mbti;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OnboardingRequest {
+
+	@NotEmpty(message = "대표 사진을 최소 1장 추가해주세요.")
+	@Size(max = 3, message = "사진은 최대 3장까지 업로드 가능합니다.")
+	private List<String> imageUrls;
+
+	@NotNull(message = "성별을 선택해주세요.")
+	private Gender gender;
+
+	@NotBlank(message = "대학교를 입력해주세요.")
+	private String university;
+
+	@NotBlank(message = "직책을 입력해주세요.")
+	private String position;
+
+	@NotNull(message = "MBTI를 선택해주세요.")
+	private Mbti mbti;
+}

--- a/src/main/java/com/lion/be/user/controller/dto/OnboardingResponse.java
+++ b/src/main/java/com/lion/be/user/controller/dto/OnboardingResponse.java
@@ -1,0 +1,26 @@
+package com.lion.be.user.controller.dto;
+
+import com.lion.be.user.domain.OnboardingStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OnboardingResponse {
+	private Long userId;
+	private String message;
+	private OnboardingStatus status;
+
+	public static OnboardingResponse success(Long userId) {
+		return OnboardingResponse.builder()
+			.userId(userId)
+			.message("온보딩이 완료되었습니다.")
+			.status(OnboardingStatus.COMPLETED)
+			.build();
+	}
+}

--- a/src/main/java/com/lion/be/user/controller/dto/UserCardFilterRequest.java
+++ b/src/main/java/com/lion/be/user/controller/dto/UserCardFilterRequest.java
@@ -1,0 +1,24 @@
+package com.lion.be.user.controller.dto;
+
+import com.lion.be.user.domain.Gender;
+import com.lion.be.user.domain.Mbti;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserCardFilterRequest {
+	private Gender preferredGender;
+	private Mbti preferredMbti;
+	private String preferredUniversity;
+	private String preferredPosition;
+
+	// 페이지네이션
+	private int page = 0;
+	private int size = 10;
+}

--- a/src/main/java/com/lion/be/user/controller/dto/UserCardFilterRequest.java
+++ b/src/main/java/com/lion/be/user/controller/dto/UserCardFilterRequest.java
@@ -18,7 +18,4 @@ public class UserCardFilterRequest {
 	private String preferredUniversity;
 	private String preferredPosition;
 
-	// 페이지네이션
-	private int page = 0;
-	private int size = 10;
 }

--- a/src/main/java/com/lion/be/user/controller/dto/UserCardResponse.java
+++ b/src/main/java/com/lion/be/user/controller/dto/UserCardResponse.java
@@ -25,11 +25,6 @@ public class UserCardResponse {
 	private Gender gender;
 	private List<String> imageUrls; // 사진 1~3장
 
-	// 페이지네이션 정보 (선택사항)
-	private boolean hasNext; // 다음 페이지 있는지
-	private int currentPage;
-	private int totalElements;
-
 	// User 엔티티에서 변환하는 정적 메서드
 	public static UserCardResponse from(User user) {
 		return UserCardResponse.builder()

--- a/src/main/java/com/lion/be/user/controller/dto/UserCardResponse.java
+++ b/src/main/java/com/lion/be/user/controller/dto/UserCardResponse.java
@@ -1,0 +1,47 @@
+package com.lion.be.user.controller.dto;
+
+import java.util.List;
+
+import com.lion.be.user.domain.Gender;
+import com.lion.be.user.domain.Mbti;
+import com.lion.be.user.domain.entity.User;
+import com.lion.be.user.domain.entity.UserPhoto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserCardResponse {
+	private Long userId;
+	private String name;
+	private String university;
+	private String position;
+	private Mbti mbti;
+	private Gender gender;
+	private List<String> imageUrls; // 사진 1~3장
+
+	// 페이지네이션 정보 (선택사항)
+	private boolean hasNext; // 다음 페이지 있는지
+	private int currentPage;
+	private int totalElements;
+
+	// User 엔티티에서 변환하는 정적 메서드
+	public static UserCardResponse from(User user) {
+		return UserCardResponse.builder()
+			.userId(user.getId())
+			.name(user.getName())
+			.university(user.getUniversity())
+			.position(user.getPosition())
+			.mbti(user.getMbti())
+			.gender(user.getGender())
+			.imageUrls(user.getUserPhotos().stream()
+				.map(UserPhoto::getImageUrl)
+				.toList())
+			.build();
+	}
+}

--- a/src/main/java/com/lion/be/user/domain/Gender.java
+++ b/src/main/java/com/lion/be/user/domain/Gender.java
@@ -1,0 +1,6 @@
+package com.lion.be.user.domain;
+
+public enum Gender {
+	WOMEN,
+	MEN
+}

--- a/src/main/java/com/lion/be/user/domain/Mbti.java
+++ b/src/main/java/com/lion/be/user/domain/Mbti.java
@@ -1,0 +1,20 @@
+package com.lion.be.user.domain;
+
+public enum Mbti {
+	ENTJ,
+	ENTP,
+	ENFJ,
+	ENFP,
+	ESTJ,
+	ESTP,
+	ESFJ,
+	ESFP,
+	INTJ,
+	INTP,
+	INFJ,
+	INFP,
+	ISTJ,
+	ISTP,
+	ISFJ,
+	ISFP,
+}

--- a/src/main/java/com/lion/be/user/domain/OnboardingStatus.java
+++ b/src/main/java/com/lion/be/user/domain/OnboardingStatus.java
@@ -1,0 +1,6 @@
+package com.lion.be.user.domain;
+
+public enum OnboardingStatus {
+	PENDING,
+	COMPLETED,
+}

--- a/src/main/java/com/lion/be/user/domain/entity/User.java
+++ b/src/main/java/com/lion/be/user/domain/entity/User.java
@@ -1,16 +1,25 @@
 package com.lion.be.user.domain.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.lion.be.chat.domain.chatroomuser.entity.ChatRoomUser;
+import com.lion.be.global.entity.BaseEntity;
+import com.lion.be.user.domain.Gender;
+import com.lion.be.user.domain.Mbti;
+import com.lion.be.user.domain.OnboardingStatus;
 import com.lion.be.user.domain.Role;
+import com.lion.be.user.domain.entity.dto.OnboardingData;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,7 +28,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "member")
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,11 +40,28 @@ public class User {
 
     private String imageUrl;
 
+    @Enumerated(EnumType.STRING)
     private Role role;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatRoomUser> chatRoomUsers = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserPhoto> userPhotos = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    private String university;
+
+    private String position;
+
+    @Enumerated(EnumType.STRING)
+    private Mbti mbti;
+
+    @Enumerated(EnumType.STRING)
+    private OnboardingStatus onboardingStatus = OnboardingStatus.PENDING;
+    
     public User(String name, String email, String imageUrl, Role role) {
         this.name = name;
         this.email = email;
@@ -45,6 +71,46 @@ public class User {
 
     public String getRoleKey() {
         return this.role.getKey();
+    }
+
+    public void completeOnboarding(OnboardingData data) {
+        validateOnboardingPreconditions();
+        validateOnboardingData(data);
+        this.gender = data.getGender();
+        this.university = data.getUniversity();
+        this.position = data.getPosition();
+        this.mbti = data.getMbti();
+
+        for (int i = 0; i < data.getImageUrls().size(); i++) {
+            this.userPhotos.add(new UserPhoto(this, data.getImageUrls().get(i), i + 1));
+        }
+        this.onboardingStatus = OnboardingStatus.COMPLETED;
+    }
+
+    public boolean isOnboardingCompleted() {
+        return onboardingStatus == OnboardingStatus.COMPLETED;
+    }
+
+    private void validateOnboardingPreconditions() {
+        if (isOnboardingCompleted()) {
+            throw new IllegalStateException("이미 온보딩이 완료된 사용자입니다.");
+        }
+        if (this.name == null || this.email == null) {
+            throw new IllegalStateException("기본 사용자 정보가 누락되었습니다.");
+        }
+    }
+
+    private void validateOnboardingData(OnboardingData data) {
+        if (data.getGender() == null || data.getUniversity() == null ||
+            data.getPosition() == null || data.getMbti() == null || data.getImageUrls() == null) {
+            throw new IllegalArgumentException("온보딩 필수 정보가 누락되었습니다.");
+        }
+        if (data.getImageUrls().isEmpty()) {
+            throw new IllegalArgumentException("최소 1장의 사진이 필요합니다.");
+        }
+        if (data.getImageUrls().size() > 3) {
+            throw new IllegalArgumentException("사진은 최대 3장까지 업로드 가능합니다.");
+        }
     }
 
 }

--- a/src/main/java/com/lion/be/user/domain/entity/UserPhoto.java
+++ b/src/main/java/com/lion/be/user/domain/entity/UserPhoto.java
@@ -1,0 +1,32 @@
+package com.lion.be.user.domain.entity;
+
+import com.lion.be.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "user_photo")
+public class UserPhoto extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	private String imageUrl;
+
+	private int orderIndex; // 사진 순서 (1, 2, 3)
+
+	public UserPhoto(User user, String imageUrl, int orderIndex) {
+		this.user = user;
+		this.imageUrl = imageUrl;
+		this.orderIndex = orderIndex;
+	}
+}

--- a/src/main/java/com/lion/be/user/domain/entity/dto/OnboardingData.java
+++ b/src/main/java/com/lion/be/user/domain/entity/dto/OnboardingData.java
@@ -1,0 +1,29 @@
+package com.lion.be.user.domain.entity.dto;
+
+import java.util.List;
+
+import com.lion.be.user.controller.dto.OnboardingRequest;
+import com.lion.be.user.domain.Gender;
+import com.lion.be.user.domain.Mbti;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OnboardingData {
+	private final Gender gender;
+	private final String university;
+	private final String position;
+	private final Mbti mbti;
+	private final List<String> imageUrls;
+
+	public static OnboardingData from(OnboardingRequest request) {
+		return OnboardingData.builder()
+			.gender(request.getGender())
+			.university(request.getUniversity())
+			.position(request.getPosition())
+			.mbti(request.getMbti())
+			.imageUrls(request.getImageUrls())
+			.build();
+	}
+}

--- a/src/main/java/com/lion/be/user/repository/UserRepository.java
+++ b/src/main/java/com/lion/be/user/repository/UserRepository.java
@@ -14,5 +14,10 @@ public interface UserRepository {
 
     Optional<User> fetchById(Long userId);
 
-    List<User> findMatchingUsers(Long currentUserId, UserCardFilterRequest request);
+    List<User> findMatchingUsersExcluding(
+        Long currentUserId,
+        UserCardFilterRequest filterRequest,
+        int size,
+        List<Long> excludeUserIds
+    );
 }

--- a/src/main/java/com/lion/be/user/repository/UserRepository.java
+++ b/src/main/java/com/lion/be/user/repository/UserRepository.java
@@ -1,6 +1,9 @@
 package com.lion.be.user.repository;
 
+import com.lion.be.user.controller.dto.UserCardFilterRequest;
 import com.lion.be.user.domain.entity.User;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository {
@@ -11,4 +14,5 @@ public interface UserRepository {
 
     Optional<User> fetchById(Long userId);
 
+    List<User> findMatchingUsers(Long currentUserId, UserCardFilterRequest request);
 }

--- a/src/main/java/com/lion/be/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/lion/be/user/repository/UserRepositoryImpl.java
@@ -1,9 +1,14 @@
 package com.lion.be.user.repository;
 
+import com.lion.be.user.controller.dto.UserCardFilterRequest;
 import com.lion.be.user.domain.entity.User;
 import com.lion.be.user.repository.persistence.jpa.UserJpaRepository;
+
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -25,6 +30,18 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public Optional<User> fetchById(Long userId) {
         return userJpaRepository.findById(userId);
+    }
+
+    @Override
+    public List<User> findMatchingUsers(Long currentUserId, UserCardFilterRequest request) {
+        return userJpaRepository.findMatchingUsers(
+            currentUserId,
+            request.getPreferredGender(),
+            request.getPreferredMbti(),
+            request.getPreferredUniversity(),
+            request.getPreferredPosition(),
+            PageRequest.of(request.getPage(), request.getSize())
+        );
     }
 
 }

--- a/src/main/java/com/lion/be/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/lion/be/user/repository/UserRepositoryImpl.java
@@ -1,3 +1,4 @@
+// UserRepositoryImpl.java - 수정된 버전
 package com.lion.be.user.repository;
 
 import com.lion.be.user.controller.dto.UserCardFilterRequest;
@@ -9,6 +10,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -33,15 +35,36 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public List<User> findMatchingUsers(Long currentUserId, UserCardFilterRequest request) {
-        return userJpaRepository.findMatchingUsers(
-            currentUserId,
-            request.getPreferredGender(),
-            request.getPreferredMbti(),
-            request.getPreferredUniversity(),
-            request.getPreferredPosition(),
-            PageRequest.of(request.getPage(), request.getSize())
-        );
+    public List<User> findMatchingUsersExcluding(
+        Long currentUserId,
+        UserCardFilterRequest filterRequest,
+        int size,
+        List<Long> excludeUserIds
+    ) {
+        Pageable pageable = PageRequest.of(0, size);
+
+        // 제외 목록이 있고 비어있지 않은 경우에만 제외 쿼리 사용
+        if (excludeUserIds != null && !excludeUserIds.isEmpty()) {
+            return userJpaRepository.findMatchingUsersWithExclusion(
+                currentUserId,
+                excludeUserIds,
+                filterRequest.getPreferredGender(),
+                filterRequest.getPreferredMbti(),
+                filterRequest.getPreferredUniversity(),
+                filterRequest.getPreferredPosition(),
+                pageable
+            );
+        } else {
+            // 제외 목록이 없거나 비어있으면 기본 쿼리 사용
+            return userJpaRepository.findMatchingUsers(
+                currentUserId,
+                filterRequest.getPreferredGender(),
+                filterRequest.getPreferredMbti(),
+                filterRequest.getPreferredUniversity(),
+                filterRequest.getPreferredPosition(),
+                pageable
+            );
+        }
     }
 
 }

--- a/src/main/java/com/lion/be/user/repository/persistence/jpa/UserJpaRepository.java
+++ b/src/main/java/com/lion/be/user/repository/persistence/jpa/UserJpaRepository.java
@@ -1,11 +1,36 @@
 package com.lion.be.user.repository.persistence.jpa;
 
+import com.lion.be.user.domain.Gender;
+import com.lion.be.user.domain.Mbti;
 import com.lion.be.user.domain.entity.User;
+
+import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import org.springframework.data.repository.query.Param;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    @Query("""
+    SELECT u FROM User u WHERE 
+    u.id != :currentUserId AND 
+    u.onboardingStatus = 'COMPLETED' AND 
+    (:preferredGender IS NULL OR u.gender = :preferredGender) AND 
+    (:preferredMbti IS NULL OR u.mbti = :preferredMbti) AND 
+    (:preferredUniversity IS NULL OR u.university LIKE %:preferredUniversity%) AND 
+    (:preferredPosition IS NULL OR u.position LIKE %:preferredPosition%)
+    """)
+    List<User> findMatchingUsers(@Param("currentUserId") Long currentUserId,
+        @Param("preferredGender") Gender preferredGender,
+        @Param("preferredMbti") Mbti preferredMbti,
+        @Param("preferredUniversity") String preferredUniversity,
+        @Param("preferredPosition") String preferredPosition,
+        Pageable pageable);
 
 }

--- a/src/main/java/com/lion/be/user/repository/persistence/jpa/UserJpaRepository.java
+++ b/src/main/java/com/lion/be/user/repository/persistence/jpa/UserJpaRepository.java
@@ -25,8 +25,28 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     (:preferredMbti IS NULL OR u.mbti = :preferredMbti) AND 
     (:preferredUniversity IS NULL OR u.university LIKE %:preferredUniversity%) AND 
     (:preferredPosition IS NULL OR u.position LIKE %:preferredPosition%)
+    ORDER BY u.createdAt DESC
     """)
     List<User> findMatchingUsers(@Param("currentUserId") Long currentUserId,
+        @Param("preferredGender") Gender preferredGender,
+        @Param("preferredMbti") Mbti preferredMbti,
+        @Param("preferredUniversity") String preferredUniversity,
+        @Param("preferredPosition") String preferredPosition,
+        Pageable pageable);
+
+    @Query("""
+    SELECT u FROM User u WHERE 
+    u.id != :currentUserId AND 
+    u.id NOT IN :excludeUserIds AND
+    u.onboardingStatus = 'COMPLETED' AND 
+    (:preferredGender IS NULL OR u.gender = :preferredGender) AND 
+    (:preferredMbti IS NULL OR u.mbti = :preferredMbti) AND 
+    (:preferredUniversity IS NULL OR u.university LIKE %:preferredUniversity%) AND 
+    (:preferredPosition IS NULL OR u.position LIKE %:preferredPosition%)
+    ORDER BY u.createdAt DESC
+    """)
+    List<User> findMatchingUsersWithExclusion(@Param("currentUserId") Long currentUserId,
+        @Param("excludeUserIds") List<Long> excludeUserIds,
         @Param("preferredGender") Gender preferredGender,
         @Param("preferredMbti") Mbti preferredMbti,
         @Param("preferredUniversity") String preferredUniversity,

--- a/src/main/java/com/lion/be/user/service/UserReadService.java
+++ b/src/main/java/com/lion/be/user/service/UserReadService.java
@@ -1,6 +1,10 @@
 package com.lion.be.user.service;
 
+import java.util.List;
+
 import com.lion.be.auth.controller.dto.CurrentUserResponse;
+import com.lion.be.user.controller.dto.UserCardFilterRequest;
+import com.lion.be.user.controller.dto.UserCardResponse;
 import com.lion.be.user.domain.entity.User;
 import com.lion.be.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,4 +33,10 @@ public class UserReadService {
                 .orElseThrow(() -> new RuntimeException("fetchById"));
     }
 
+    public List<UserCardResponse> getMatchingCards(Long currentUserId, UserCardFilterRequest request) {
+        List<User> matchingUsers = userRepository.findMatchingUsers(currentUserId, request);
+        return matchingUsers.stream()
+            .map(UserCardResponse::from)
+            .toList();
+    }
 }

--- a/src/main/java/com/lion/be/user/service/UserReadService.java
+++ b/src/main/java/com/lion/be/user/service/UserReadService.java
@@ -2,14 +2,17 @@ package com.lion.be.user.service;
 
 import java.util.List;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.lion.be.auth.controller.dto.CurrentUserResponse;
+import com.lion.be.global.exception.OnboardingNotCompletedException;
 import com.lion.be.user.controller.dto.UserCardFilterRequest;
 import com.lion.be.user.controller.dto.UserCardResponse;
 import com.lion.be.user.domain.entity.User;
 import com.lion.be.user.repository.UserRepository;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -33,10 +36,31 @@ public class UserReadService {
                 .orElseThrow(() -> new RuntimeException("fetchById"));
     }
 
-    public List<UserCardResponse> getMatchingCards(Long currentUserId, UserCardFilterRequest request) {
-        List<User> matchingUsers = userRepository.findMatchingUsers(currentUserId, request);
+    public List<UserCardResponse> getMatchingCards(
+        Long currentUserId,
+        UserCardFilterRequest filterRequest,
+        int size,
+        List<Long> excludeUserIds
+    ) {
+        validateOnboardingCompleted(currentUserId);
+
+        List<User> matchingUsers = userRepository.findMatchingUsersExcluding(
+            currentUserId,
+            filterRequest,
+            size,
+            excludeUserIds
+        );
+
         return matchingUsers.stream()
             .map(UserCardResponse::from)
             .toList();
+    }
+
+    private void validateOnboardingCompleted(Long userId) {
+        User user = fetchById(userId);
+
+        if (!user.isOnboardingCompleted()) {
+            throw new OnboardingNotCompletedException();
+        }
     }
 }

--- a/src/main/java/com/lion/be/user/service/UserWriteService.java
+++ b/src/main/java/com/lion/be/user/service/UserWriteService.java
@@ -1,10 +1,16 @@
 package com.lion.be.user.service;
 
-import com.lion.be.user.domain.entity.User;
-import com.lion.be.user.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.lion.be.global.exception.UserNotFoundException;
+import com.lion.be.user.controller.dto.OnboardingRequest;
+import com.lion.be.user.controller.dto.OnboardingResponse;
+import com.lion.be.user.domain.entity.User;
+import com.lion.be.user.domain.entity.dto.OnboardingData;
+import com.lion.be.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -17,4 +23,16 @@ public class UserWriteService {
         userRepository.save(user);
     }
 
+    public OnboardingResponse completeUserOnboarding(Long userId, OnboardingRequest request) {
+        User user = userRepository.fetchById(userId)
+            .orElseThrow(UserNotFoundException::new);
+
+        user.completeOnboarding(
+            OnboardingData.from(request)
+        );
+
+        userRepository.save(user);
+
+        return OnboardingResponse.success(userId);
+    }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,5 +1,0 @@
-spring:
-  data:
-    mongodb:
-      uri: mongodb://admin:admin@localhost:27017/chat_db?authSource=admin
-      database: chat_db

--- a/src/test/java/com/lion/be/acceptance/user/UserAcceptanceTest.java
+++ b/src/test/java/com/lion/be/acceptance/user/UserAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.lion.be.acceptance.user;
 
 import static com.lion.be.acceptance.auth.AuthSteps.비회원이_로그인한다;
 import static com.lion.be.acceptance.user.UserSteps.*;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
 
 import com.lion.be.acceptance.AcceptanceTest;
 import com.lion.be.acceptance.util.UserFixture;
@@ -112,25 +113,89 @@ class UserAcceptanceTest extends AcceptanceTest {
             상태코드가_200이다(response);
         }
 
-
-        @DisplayName("페이지네이션을 적용해서 매칭 카드를 조회하면, 페이징된 결과를 반환한다.")
+        @DisplayName("제외 목록을 적용해서 매칭 카드를 조회하면, 제외된 사용자는 결과에 포함되지 않는다.")
         @Test
-        void when_get_matching_cards_with_pagination_then_response_paged_results() {
+        void when_get_matching_cards_with_exclusion_then_excluded_users_not_in_results() {
+            // given
+            api_문서_타이틀("getMatchingCards_with_exclusion", spec);
+
+            // 카드를 조회할 사용자
+            var user1LoginResponse = 비회원이_로그인한다(spec);
+            String user1AccessToken = user1LoginResponse.jsonPath().getString("accessToken");
+            온보딩을_완료한다(UserFixture.회원_멋사2_온보딩_요청(), user1AccessToken, spec);
+
+            // 매칭될 사용자들
+            var user2LoginResponse = 원준이_로그인한다(spec);
+            String user2AccessToken = user2LoginResponse.jsonPath().getString("accessToken");
+            온보딩을_완료한다(UserFixture.회원_멋사_온보딩_요청(), user2AccessToken, spec);
+
+            // 첫 번째 조회로 user2의 ID 획득
+            var firstResponse = 매칭_카드를_조회한다(user1AccessToken, spec);
+            String user2Id = firstResponse.jsonPath().getString("[0].userId");
+
+            // when - user2를 제외하고 조회
+            var response = 제외_목록으로_매칭_카드를_조회한다(user1AccessToken, spec, user2Id);
+
+            // then
+            상태코드가_200이다(response);
+            // 제외된 사용자가 결과에 없는지 검증
+            var userIds = response.jsonPath().getList("userId", String.class);
+            assertThat(userIds).doesNotContain(user2Id);
+        }
+
+        @DisplayName("사이즈 파라미터를 적용해서 매칭 카드를 조회하면, 지정된 개수만큼 결과를 반환한다.")
+        @Test
+        void when_get_matching_cards_with_size_then_return_limited_results() {
             // given
             var user1LoginResponse = 비회원이_로그인한다(spec);
             String user1AccessToken = user1LoginResponse.jsonPath().getString("accessToken");
             온보딩을_완료한다(UserFixture.회원_멋사2_온보딩_요청(), user1AccessToken, spec);
 
-            // 여러 사용자 생성해서 페이징 효과 확인
+            // 여러 사용자 생성
             var user2LoginResponse = 원준이_로그인한다(spec);
             String user2AccessToken = user2LoginResponse.jsonPath().getString("accessToken");
             온보딩을_완료한다(UserFixture.회원_멋사_온보딩_요청(), user2AccessToken, spec);
 
             // when
-            var response = 페이지네이션으로_매칭_카드를_조회한다(user1AccessToken, spec);
+            var response = 사이즈_제한으로_매칭_카드를_조회한다(user1AccessToken, spec, 5);
 
             // then
             상태코드가_200이다(response);
+            assertThat(response.jsonPath().getList("$").size()).isLessThanOrEqualTo(5);
+        }
+
+        @DisplayName("필터 조건과 제외 목록을 함께 적용해서 매칭 카드를 조회하면, 두 조건이 모두 적용된 결과를 반환한다.")
+        @Test
+        void when_get_matching_cards_with_filter_and_exclusion_then_both_conditions_applied() {
+            // given
+            var user1LoginResponse = 비회원이_로그인한다(spec);
+            String user1AccessToken = user1LoginResponse.jsonPath().getString("accessToken");
+            온보딩을_완료한다(UserFixture.회원_멋사2_온보딩_요청(), user1AccessToken, spec);
+
+            var user2LoginResponse = 원준이_로그인한다(spec);
+            String user2AccessToken = user2LoginResponse.jsonPath().getString("accessToken");
+            온보딩을_완료한다(UserFixture.회원_멋사_온보딩_요청(), user2AccessToken, spec);
+
+            // when
+            var response = 필터_및_제외_목록으로_매칭_카드를_조회한다(user1AccessToken, spec);
+
+            // then
+            상태코드가_200이다(response);
+        }
+
+        @DisplayName("온보딩하지 않은 회원이 매칭 카드를 조회하면, 상태코드 400을 반환한다.")
+        @Test
+        void when_non_onboarded_user_get_matching_cards_then_response_400() {
+            // given
+            var loginResponse = 비회원이_로그인한다(spec);
+            String accessToken = loginResponse.jsonPath().getString("accessToken");
+            // 온보딩하지 않음
+
+            // when
+            var response = 매칭_카드를_조회한다(accessToken, spec);
+
+            // then
+            상태코드가_400이다(response);
         }
     }
 

--- a/src/test/java/com/lion/be/acceptance/user/UserAcceptanceTest.java
+++ b/src/test/java/com/lion/be/acceptance/user/UserAcceptanceTest.java
@@ -53,7 +53,7 @@ class UserAcceptanceTest extends AcceptanceTest {
                 .spec(spec)
                 .auth().oauth2(accessToken)
                 .log().all()  // 요청 로그
-                .body(UserFixture.비회원_온보딩_요청())
+                .body(UserFixture.회원_멋사2_온보딩_요청())
                 .when()
                 .patch("/api/user/onboarding")
                 .then()
@@ -79,7 +79,7 @@ class UserAcceptanceTest extends AcceptanceTest {
             // 첫 번째 사용자 (카드를 조회할 사용자)
             var user1LoginResponse = 비회원이_로그인한다(spec);
             String user1AccessToken = user1LoginResponse.jsonPath().getString("accessToken");
-            온보딩을_완료한다(UserFixture.비회원_온보딩_요청(), user1AccessToken, spec);
+            온보딩을_완료한다(UserFixture.회원_멋사2_온보딩_요청(), user1AccessToken, spec);
 
             // 두 번째 사용자 (매칭될 카드)
             var user2LoginResponse = 원준이_로그인한다(spec);
@@ -99,7 +99,7 @@ class UserAcceptanceTest extends AcceptanceTest {
             // given
             var user1LoginResponse = 비회원이_로그인한다(spec);
             String user1AccessToken = user1LoginResponse.jsonPath().getString("accessToken");
-            온보딩을_완료한다(UserFixture.비회원_온보딩_요청(), user1AccessToken, spec);
+            온보딩을_완료한다(UserFixture.회원_멋사2_온보딩_요청(), user1AccessToken, spec);
 
             var user2LoginResponse = 원준이_로그인한다(spec);
             String user2AccessToken = user2LoginResponse.jsonPath().getString("accessToken");
@@ -119,7 +119,7 @@ class UserAcceptanceTest extends AcceptanceTest {
             // given
             var user1LoginResponse = 비회원이_로그인한다(spec);
             String user1AccessToken = user1LoginResponse.jsonPath().getString("accessToken");
-            온보딩을_완료한다(UserFixture.비회원_온보딩_요청(), user1AccessToken, spec);
+            온보딩을_완료한다(UserFixture.회원_멋사2_온보딩_요청(), user1AccessToken, spec);
 
             // 여러 사용자 생성해서 페이징 효과 확인
             var user2LoginResponse = 원준이_로그인한다(spec);

--- a/src/test/java/com/lion/be/acceptance/user/UserAcceptanceTest.java
+++ b/src/test/java/com/lion/be/acceptance/user/UserAcceptanceTest.java
@@ -1,12 +1,17 @@
 package com.lion.be.acceptance.user;
 
 import static com.lion.be.acceptance.auth.AuthSteps.비회원이_로그인한다;
-import static com.lion.be.acceptance.user.UserSteps.상태코드가_200이다;
+import static com.lion.be.acceptance.user.UserSteps.*;
 
 import com.lion.be.acceptance.AcceptanceTest;
+import com.lion.be.acceptance.util.UserFixture;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import io.restassured.RestAssured;
 
 @DisplayName("회원 관련 기능 인수테스트")
 class UserAcceptanceTest extends AcceptanceTest {
@@ -26,6 +31,37 @@ class UserAcceptanceTest extends AcceptanceTest {
 
             // then
             상태코드가_200이다(response);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("온보딩 인수테스트")
+    class OnboardingTest {
+
+        @DisplayName("신규 회원이 온보딩을 완료하면, 상태코드 200과 완료 메시지를 반환한다.")
+        @Test
+        void when_new_user_complete_onboarding_then_response_200() {
+            // given
+            var loginResponse = 비회원이_로그인한다(spec);
+            String accessToken = loginResponse.jsonPath().getString("accessToken");
+
+            // when
+            var onboardingResponse = RestAssured
+                .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .spec(spec)
+                .auth().oauth2(accessToken)
+                .log().all()  // 요청 로그
+                .body(UserFixture.비회원_온보딩_요청())
+                .when()
+                .patch("/api/user/onboarding")
+                .then()
+                .log().all()  // 응답 로그
+                .extract();
+
+            // 일단 상태코드만 확인
+            온보딩_완료_응답을_검증한다(onboardingResponse);
         }
 
     }

--- a/src/test/java/com/lion/be/acceptance/user/UserAcceptanceTest.java
+++ b/src/test/java/com/lion/be/acceptance/user/UserAcceptanceTest.java
@@ -66,4 +66,72 @@ class UserAcceptanceTest extends AcceptanceTest {
 
     }
 
+    @Nested
+    @DisplayName("사용자 카드 조회 인수테스트")
+    class UserCardQueryTest {
+
+        @DisplayName("온보딩 완료한 회원이 매칭 카드를 조회하면, 상태코드 200과 카드 목록을 반환한다.")
+        @Test
+        void when_onboarded_user_get_matching_cards_then_response_200() {
+            // given
+            api_문서_타이틀("getMatchingCards_success", spec);
+
+            // 첫 번째 사용자 (카드를 조회할 사용자)
+            var user1LoginResponse = 비회원이_로그인한다(spec);
+            String user1AccessToken = user1LoginResponse.jsonPath().getString("accessToken");
+            온보딩을_완료한다(UserFixture.비회원_온보딩_요청(), user1AccessToken, spec);
+
+            // 두 번째 사용자 (매칭될 카드)
+            var user2LoginResponse = 원준이_로그인한다(spec);
+            String user2AccessToken = user2LoginResponse.jsonPath().getString("accessToken");
+            온보딩을_완료한다(UserFixture.회원_멋사_온보딩_요청(), user2AccessToken, spec);
+
+            // when
+            var response = 매칭_카드를_조회한다(user1AccessToken, spec);
+
+            // then
+            매칭_카드_조회_응답을_검증한다(response);
+        }
+
+        @DisplayName("필터 조건을 적용해서 매칭 카드를 조회하면, 필터링된 결과를 반환한다.")
+        @Test
+        void when_get_matching_cards_with_filter_then_response_filtered_results() {
+            // given
+            var user1LoginResponse = 비회원이_로그인한다(spec);
+            String user1AccessToken = user1LoginResponse.jsonPath().getString("accessToken");
+            온보딩을_완료한다(UserFixture.비회원_온보딩_요청(), user1AccessToken, spec);
+
+            var user2LoginResponse = 원준이_로그인한다(spec);
+            String user2AccessToken = user2LoginResponse.jsonPath().getString("accessToken");
+            온보딩을_완료한다(UserFixture.회원_멋사_온보딩_요청(), user2AccessToken, spec);
+
+            // when
+            var response = 필터_조건으로_매칭_카드를_조회한다(user1AccessToken, spec);
+
+            // then
+            상태코드가_200이다(response);
+        }
+
+
+        @DisplayName("페이지네이션을 적용해서 매칭 카드를 조회하면, 페이징된 결과를 반환한다.")
+        @Test
+        void when_get_matching_cards_with_pagination_then_response_paged_results() {
+            // given
+            var user1LoginResponse = 비회원이_로그인한다(spec);
+            String user1AccessToken = user1LoginResponse.jsonPath().getString("accessToken");
+            온보딩을_완료한다(UserFixture.비회원_온보딩_요청(), user1AccessToken, spec);
+
+            // 여러 사용자 생성해서 페이징 효과 확인
+            var user2LoginResponse = 원준이_로그인한다(spec);
+            String user2AccessToken = user2LoginResponse.jsonPath().getString("accessToken");
+            온보딩을_완료한다(UserFixture.회원_멋사_온보딩_요청(), user2AccessToken, spec);
+
+            // when
+            var response = 페이지네이션으로_매칭_카드를_조회한다(user1AccessToken, spec);
+
+            // then
+            상태코드가_200이다(response);
+        }
+    }
+
 }

--- a/src/test/java/com/lion/be/acceptance/user/UserSteps.java
+++ b/src/test/java/com/lion/be/acceptance/user/UserSteps.java
@@ -130,8 +130,47 @@ public class UserSteps {
             .extract();
     }
 
-    // 페이지네이션으로 매칭 카드 조회
-    public static ExtractableResponse<Response> 페이지네이션으로_매칭_카드를_조회한다(
+    public static ExtractableResponse<Response> 제외_목록으로_매칭_카드를_조회한다(
+        String accessToken,
+        RequestSpecification spec,
+        String excludeUserIds
+    ) {
+        return RestAssured
+            .given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .spec(spec)
+            .auth().oauth2(accessToken)
+            .queryParam("size", 10)
+            .queryParam("excludeUserIds", excludeUserIds)
+            .log().all()
+            .when()
+            .get("/api/user/card")
+            .then()
+            .log().all()
+            .extract();
+    }
+    // 사이즈 제한으로 매칭 카드 조회
+    public static ExtractableResponse<Response> 사이즈_제한으로_매칭_카드를_조회한다(
+        String accessToken,
+        RequestSpecification spec,
+        int size
+    ) {
+        return RestAssured
+            .given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .spec(spec)
+            .auth().oauth2(accessToken)
+            .queryParam("size", size)
+            .log().all()
+            .when()
+            .get("/api/user/card")
+            .then()
+            .log().all()
+            .extract();
+    }
+
+    // 필터 + 제외 목록으로 매칭 카드 조회 (기존 메서드 수정)
+    public static ExtractableResponse<Response> 필터_및_제외_목록으로_매칭_카드를_조회한다(
         String accessToken,
         RequestSpecification spec
     ) {
@@ -140,8 +179,9 @@ public class UserSteps {
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .spec(spec)
             .auth().oauth2(accessToken)
-            .queryParam("page", 0)
-            .queryParam("size", 5)
+            .queryParam("preferredGender", "MEN")
+            .queryParam("preferredMbti", "ENFP")
+            .queryParam("excludeUserIds", "999") // 존재하지 않는 ID로 테스트
             .log().all()
             .when()
             .get("/api/user/card")

--- a/src/test/java/com/lion/be/acceptance/user/UserSteps.java
+++ b/src/test/java/com/lion/be/acceptance/user/UserSteps.java
@@ -92,6 +92,100 @@ public class UserSteps {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 매칭_카드를_조회한다(
+        String accessToken,
+        RequestSpecification spec
+    ) {
+        return RestAssured
+            .given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .spec(spec)
+            .auth().oauth2(accessToken)
+            .log().all()
+            .when()
+            .get("/api/user/card")
+            .then()
+            .log().all()
+            .extract();
+    }
+
+    // 필터 조건으로 매칭 카드 조회
+    public static ExtractableResponse<Response> 필터_조건으로_매칭_카드를_조회한다(
+        String accessToken,
+        RequestSpecification spec
+    ) {
+        return RestAssured
+            .given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .spec(spec)
+            .auth().oauth2(accessToken)
+            .queryParam("preferredGender", "MEN")
+            .queryParam("preferredMbti", "ENFP")
+            .queryParam("preferredUniversity", "멋사대학교")
+            .log().all()
+            .when()
+            .get("/api/user/card")
+            .then()
+            .log().all()
+            .extract();
+    }
+
+    // 페이지네이션으로 매칭 카드 조회
+    public static ExtractableResponse<Response> 페이지네이션으로_매칭_카드를_조회한다(
+        String accessToken,
+        RequestSpecification spec
+    ) {
+        return RestAssured
+            .given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .spec(spec)
+            .auth().oauth2(accessToken)
+            .queryParam("page", 0)
+            .queryParam("size", 5)
+            .log().all()
+            .when()
+            .get("/api/user/card")
+            .then()
+            .log().all()
+            .extract();
+    }
+
+    // 원준이 로그인 (UserFixture에 이미 있는 데이터 활용)
+    public static ExtractableResponse<Response> 원준이_로그인한다(RequestSpecification spec) {
+        return RestAssured
+            .given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .spec(spec)
+            .log().all()
+            .body(UserFixture.사용자_원준_회원가입_요청())
+            .when()
+            .post("/api/test/login")
+            .then()
+            .log().all()
+            .extract();
+    }
+
+    // 매칭 카드 조회 응답 검증
+    public static void 매칭_카드_조회_응답을_검증한다(ExtractableResponse<Response> response) {
+        Assertions.assertAll(
+            () -> 상태코드를_검증한다(response, HttpStatus.OK),
+            () -> assertThat(response.jsonPath().getList("$")).isNotNull(),
+            () -> {
+                // 카드가 있다면 첫 번째 카드의 필수 필드들 검증
+                if (!response.jsonPath().getList("$").isEmpty()) {
+                    assertThat(response.jsonPath().getString("[0].userId")).isNotNull();
+                    assertThat(response.jsonPath().getString("[0].name")).isNotNull();
+                    assertThat(response.jsonPath().getString("[0].university")).isNotNull();
+                    assertThat(response.jsonPath().getString("[0].position")).isNotNull();
+                    assertThat(response.jsonPath().getString("[0].mbti")).isNotNull();
+                    assertThat(response.jsonPath().getString("[0].gender")).isNotNull();
+                    assertThat(response.jsonPath().getList("[0].imageUrls")).isNotNull();
+                }
+            }
+        );
+    }
+
+
     public static void 상태코드가_200이다(ExtractableResponse<Response> response) {
         Assertions.assertAll(
                 () -> 상태코드를_검증한다(response, HttpStatus.OK)
@@ -105,12 +199,19 @@ public class UserSteps {
         );
     }
 
+    public static void 상태코드가_400이다(ExtractableResponse<Response> response) {
+        Assertions.assertAll(
+            () -> 상태코드를_검증한다(response, HttpStatus.BAD_REQUEST)
+        );
+    }
+
     public static void 상태코드가_404이다(
             ExtractableResponse<Response> response) {
         Assertions.assertAll(
                 () -> 상태코드를_검증한다(response, HttpStatus.NOT_FOUND)
         );
     }
+
 
     public static AbstractIntegerAssert<?> 상태코드를_검증한다(ExtractableResponse<Response> response,
                                                       HttpStatus expectedHttpStatus) {

--- a/src/test/java/com/lion/be/acceptance/user/UserSteps.java
+++ b/src/test/java/com/lion/be/acceptance/user/UserSteps.java
@@ -33,6 +33,35 @@ public class UserSteps {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 온보딩을_완료한다(
+        Map<String, Object> onboardingRequest,
+        String accessToken,
+        RequestSpecification spec
+    ) {
+        return RestAssured
+            .given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .spec(spec)
+            .auth().oauth2(accessToken)
+            .log().all()
+            .body(onboardingRequest)
+            .when()
+            .patch("/api/user/onboarding")
+            .then()
+            .log().all()
+            .extract();
+    }
+
+    public static void 온보딩_완료_응답을_검증한다(ExtractableResponse<Response> response) {
+        Assertions.assertAll(
+            () -> 상태코드를_검증한다(response, HttpStatus.OK),
+            () -> assertThat(response.jsonPath().getString("message"))
+                .isEqualTo("온보딩이 완료되었습니다."),
+            () -> assertThat(response.jsonPath().getString("status"))
+                .isEqualTo("COMPLETED")
+        );
+    }
+
     public static ExtractableResponse<Response> 로그인한다(Map<String, Object> userSaveRequest,
                                                       RequestSpecification spec) {
         return RestAssured

--- a/src/test/java/com/lion/be/acceptance/util/UserFixture.java
+++ b/src/test/java/com/lion/be/acceptance/util/UserFixture.java
@@ -1,5 +1,6 @@
 package com.lion.be.acceptance.util;
 
+import java.util.List;
 import java.util.Map;
 
 public enum UserFixture {
@@ -31,4 +32,24 @@ public enum UserFixture {
     public String getImageUrl() {
         return imageUrl;
     }
+
+    public static Map<String, Object> 회원_멋사_온보딩_요청(){
+        return Map.of(
+            "imageUrls", List.of("photo1.jpg", "photo2.jpg"),
+            "gender", "MEN",
+            "university", "멋사대학교",
+            "position", "개발자",
+            "mbti", "ENFP"
+        );
+    }
+    public static Map<String, Object> 비회원_온보딩_요청() {
+        return Map.of(
+            "imageUrls", List.of("photo1.jpg"),
+            "gender", "WOMEN",
+            "university", "연세대학교",
+            "position", "디자이너",
+            "mbti", "INFP"
+        );
+    }
+
 }

--- a/src/test/java/com/lion/be/acceptance/util/UserFixture.java
+++ b/src/test/java/com/lion/be/acceptance/util/UserFixture.java
@@ -42,7 +42,7 @@ public enum UserFixture {
             "mbti", "ENFP"
         );
     }
-    public static Map<String, Object> 비회원_온보딩_요청() {
+    public static Map<String, Object> 회원_멋사2_온보딩_요청() {
         return Map.of(
             "imageUrls", List.of("photo1.jpg"),
             "gender", "WOMEN",


### PR DESCRIPTION
## 소셜 로그인 이후 유저 온보딩 api 생성
- user 테이블에 컬럼 추가
PATCH `http://localhost:8080/api/user/onboarding`

입력값

```
{
    "imageUrls": ["d" ],
    "gender": "MEN",
    "university": "gk",
    "position": "be",
    "mbti": "ENFJ"
}
```

반환 값

 ```
{
  "userId": 2,
  "message": "온보딩이 완료되었습니다.",
  "status": "COMPLETED"
}
```

mbti, gender 이넘값
## 유저 카드조회 api
- 유저 카드 조회
GET `http://localhost:8080/api/user/card`

반환값

```
[
  {
    "userId": 1,
    "name": "정원준",
    "university": "멋사대학교", 
    "position": "개발자",
    "mbti": "ENFP",
    "gender": "MEN",
    "imageUrls": [
      "photo1.jpg",
      "photo2.jpg"
    ]
  },
  {
    "userId": 2,
    "name": "성이름",
    "university": "연세대학교",
    "position": "디자이너", 
    "mbti": "INFP",
    "gender": "WOMEN",
    "imageUrls": [
      "photo3.jpg"
    ]
  },
  {
    "userId": 3,
    "name": "김철수",
    "university": "서울대학교",
    "position": "기획자",
    "mbti": "INTJ", 
    "gender": "MEN",
    "imageUrls": [
      "photo4.jpg",
      "photo5.jpg",
      "photo6.jpg"
    ]
  }
]
```
## 고민중인 사항
- filter를 따로 테이블로 분리하여 사용할지? 
   - (현재 dto로 파람값 받아서 처리중, 테이블로 분리하면 데이터 분석 또는 이전 검색불러오기등 활용가능)
- filter를 현재 jpa 쿼리로 조회중인데 queryDSL 적용할지? 
