### PR TITLE
Feat/#96 유저 벤시스템 적용

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -650,7 +650,7 @@ operation::like_notification_sent[snippets='http-request,http-response']
 
 이미지를 업로드하면 성공한다.
 
-=== http-request
+*http-request**
 ```http
 POST /api/images/upload/list HTTP/1.1
 Content-Type: multipart/form-data; boundary="jS1C_feE6jbyqap2dn9V0uCfgbOsfk1"; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -663,7 +663,7 @@ dummy-image-content
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--
 ```
 
-=== http-response
+*http-response*
 
 ```http
 Vary: Origin
@@ -692,7 +692,7 @@ Content-Length: 520
 
 이미지를 2장 업로드시 성공한다.
 
-=== http-request
+*ttp-request*
 ```http
 POST /api/images/upload/list HTTP/1.1
 Content-Type: multipart/form-data; boundary="jS1C_feE6jbyqap2dn9V0uCfgbOsfk1"; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -711,7 +711,7 @@ dummy-image-content
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--
 ```
 
-=== http-response
+*http-response*
 
 ```http
 Vary: Origin
@@ -746,15 +746,13 @@ Content-Length: 520
 
 업로드된 이미지를 성공적으로 삭제한다.
 
-operation::image_delete_success[snippets='http-request,http-response']
-
-=== http-request
+*http-request*
 ```http
 DELETE /api/images/34 HTTP/1.1
 Host: localhost:50540
 ```
 
-=== http-response
+*http-response*
 
 ```http
 HTTP/1.1 200 OK
@@ -775,14 +773,13 @@ Connection: keep-alive
 
 존재 하지 않는 이미지를 삭제 404 반환한다.
 
-operation::image_delete_fail_not_found[snippets='http-request,http-response']
-=== http-request
+**http-reques**t
 ```http
 DELETE /api/images/9999 HTTP/1.1
 Host: localhost:50540
 ```
 
-=== http-response
+*http-response*
 
 ```http
 HTTP/1.1 404 Not Found
@@ -803,14 +800,13 @@ Connection: keep-alive
 
 남의 이미지를 삭제시도하면 403 반환한다.
 
-operation::image_delete_fail_access_denied[snippets='http-request,http-response']
-=== http-request
+*http-request*
 ```http
 DELETE /api/images/34 HTTP/1.1
 Host: localhost:50540
 ```
 
-=== http-response
+*http-response*
 
 ```http
 HTTP/1.1 403 Forbidden

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -60,6 +60,35 @@ operation::fetch_my_info_fail_no_token[snippets='http-request,http-response']
 [[user-management]]
 == 사용자 관리
 
+[[admin-user-ban-system]]
+=== 어드민 유저는 유저를 밴할수 있습니다.
+
+어드민 유저는 유저아이디를 통해 해당 유저를 밴할 수 있습니다.
+
+operation::should_ban_user_when_admin_requests[snippets='http-request,http-response']
+
+[[adnim-user-unban-system]]
+=== 어드민 유저는 밴된 유저를 해지 할수 있습니다.
+
+어드민 유저는 유저아이디를 통해 밴된 유저를 해지 할 수 있습니다.
+
+operation::should_unban_user_when_admin_requests[snippets='http-request,http-response']
+
+[[user-cannot-use-ban-system]]
+=== 유저는 밴시스템에 접근할수 없습니다.
+
+유저는 밴시스템에 접근할 수 없습니다. .
+
+operation::should_deny_access_when_regular_user_tries_ban[snippets='http-request,http-response']
+
+[[user-cannot-use-unban-system]]
+=== 유저는 밴해제시스템에 접근할수 없습니다.
+
+유저는 밴해제시스템에 접근할 수 없습니다. .
+
+operation::should_deny_access_when_regular_user_tries_unban[snippets='http-request,http-response']
+
+
 [[onboarding-enums]]
 === 온보딩에 필요한 이넘 리스트를 불러옵니다
 

--- a/src/main/java/com/lion/be/admin/controller/AdminUserController.java
+++ b/src/main/java/com/lion/be/admin/controller/AdminUserController.java
@@ -1,0 +1,43 @@
+package com.lion.be.admin.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.lion.be.admin.controller.dto.BanUserRequest;
+import com.lion.be.admin.controller.dto.BanUserResponse;
+import com.lion.be.admin.controller.dto.UnbanUserRequest;
+import com.lion.be.admin.controller.dto.UnbanUserResponse;
+import com.lion.be.admin.service.AdminUserWriteService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminUserController {
+
+	private final AdminUserWriteService adminUserWriteService;
+
+	@PostMapping("/ban")
+	public ResponseEntity<BanUserResponse> banUser(
+		@Valid @RequestBody BanUserRequest request
+		) {
+		BanUserResponse response = adminUserWriteService.banUser(request);
+		return ResponseEntity.ok(response);
+	}
+
+	@PatchMapping("/unban")
+	public ResponseEntity<UnbanUserResponse> unbanUser(
+		@Valid @RequestBody UnbanUserRequest request
+	){
+		UnbanUserResponse response = adminUserWriteService.unbanUser(request);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/com/lion/be/admin/controller/dto/BanUserRequest.java
+++ b/src/main/java/com/lion/be/admin/controller/dto/BanUserRequest.java
@@ -1,0 +1,10 @@
+package com.lion.be.admin.controller.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record BanUserRequest (
+	@NotNull(message = "사용자 email는 필수입니다")
+	String email,
+	String reason // 차단 사유 (선택사항)
+	){
+}

--- a/src/main/java/com/lion/be/admin/controller/dto/BanUserResponse.java
+++ b/src/main/java/com/lion/be/admin/controller/dto/BanUserResponse.java
@@ -1,0 +1,26 @@
+package com.lion.be.admin.controller.dto;
+
+import java.time.LocalDateTime;
+
+import com.lion.be.user.domain.Role;
+import com.lion.be.user.domain.entity.User;
+
+public record BanUserResponse(
+	String message,
+	Long bannedUserId,
+	String bannedUserEmail,
+	String reason,
+	Role role,
+	LocalDateTime bannedAt
+) {
+	public static BanUserResponse of(User user, String reason) {
+		return new BanUserResponse(
+			"사용자 정지를 성공하였습니다.",
+			user.getId(),
+			user.getEmail(),
+			reason,
+			user.getRole(),
+			LocalDateTime.now()
+		);
+	}
+}

--- a/src/main/java/com/lion/be/admin/controller/dto/UnbanUserRequest.java
+++ b/src/main/java/com/lion/be/admin/controller/dto/UnbanUserRequest.java
@@ -1,0 +1,10 @@
+package com.lion.be.admin.controller.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UnbanUserRequest(
+	@NotNull(message = "사용자 email는 필수입니다")
+	String email,
+	String reason
+) {
+}

--- a/src/main/java/com/lion/be/admin/controller/dto/UnbanUserResponse.java
+++ b/src/main/java/com/lion/be/admin/controller/dto/UnbanUserResponse.java
@@ -1,0 +1,26 @@
+package com.lion.be.admin.controller.dto;
+
+import java.time.LocalDateTime;
+
+import com.lion.be.user.domain.Role;
+import com.lion.be.user.domain.entity.User;
+
+public record UnbanUserResponse (
+	String message,
+	Long unbanUserId,
+	String unbanUserEmail,
+	String reason,
+	Role role,
+	LocalDateTime unbanAt
+){
+	public static UnbanUserResponse of(User user, String reason) {
+		return new UnbanUserResponse(
+			"사용자 해지를 성공하였습니다.",
+			user.getId(),
+			user.getEmail(),
+			reason,
+			user.getRole(),
+			LocalDateTime.now()
+		);
+	}
+}

--- a/src/main/java/com/lion/be/admin/service/AdminUserWriteService.java
+++ b/src/main/java/com/lion/be/admin/service/AdminUserWriteService.java
@@ -1,0 +1,47 @@
+package com.lion.be.admin.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lion.be.admin.controller.dto.BanUserRequest;
+import com.lion.be.admin.controller.dto.BanUserResponse;
+import com.lion.be.admin.controller.dto.UnbanUserRequest;
+import com.lion.be.admin.controller.dto.UnbanUserResponse;
+import com.lion.be.auth.service.RefreshTokenService;
+import com.lion.be.user.domain.Role;
+import com.lion.be.user.domain.entity.User;
+import com.lion.be.user.service.UserReadService;
+import com.lion.be.user.service.UserWriteService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminUserWriteService {
+	private final UserWriteService userWriteService;
+	private final RefreshTokenService refreshTokenService;
+	private final UserReadService userReadService;
+
+	// 사용자 차단 (Role 변경 + 토큰 처리)
+	public BanUserResponse banUser(BanUserRequest request) {
+		User user = userReadService.fetchByEmail(request.email());
+		// 1. Role 변경
+		user.updateRole(Role.BANNED);
+		userWriteService.save(user);
+		// 2. 토큰 처리
+		refreshTokenService.deleteToken(user.getEmail());
+
+		return BanUserResponse.of(user, request.reason());
+	}
+
+	// 차단 해제 (Role만 변경)
+	public UnbanUserResponse unbanUser(UnbanUserRequest request) {
+		User user = userReadService.fetchByEmail(request.email());
+
+		user.updateRole(Role.USER);
+		userWriteService.save(user);
+
+		return UnbanUserResponse.of(user, request.reason());
+	}
+}

--- a/src/main/java/com/lion/be/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/lion/be/auth/service/CustomOAuth2UserService.java
@@ -2,6 +2,9 @@ package com.lion.be.auth.service;
 
 import com.lion.be.auth.domain.OAuth2Attributes;
 import com.lion.be.auth.domain.UserPrincipal;
+import com.lion.be.global.exception.CustomException;
+import com.lion.be.global.exception.ErrorCode;
+import com.lion.be.user.domain.Role;
 import com.lion.be.user.domain.entity.User;
 import com.lion.be.user.service.UserConvertor;
 import com.lion.be.user.service.UserReadService;
@@ -52,17 +55,24 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     private User login(OAuth2Attributes attributes) {
         User user;
 
-        try {
-            // FIXME: 다른 oauth 플랫폼과 이메일이 같은 경우, 재로그인하도록 돌리기 (혹시나 시간이 없으면 카카오만)
-            user = userReadService.fetchByEmail(attributes.getEmail());
-            log.info("{} 유저 인식 완료.", attributes.getName());
-        } catch (RuntimeException e) {
-            user = UserConvertor.attributesToUser(attributes);
-            userWriteService.save(user);
-            log.info("{} 유저 최초 로그인.", attributes.getName());
-        }
+		try {
+			// FIXME: 다른 oauth 플랫폼과 이메일이 같은 경우, 재로그인하도록 돌리기 (혹시나 시간이 없으면 카카오만)
+			user = userReadService.fetchByEmail(attributes.getEmail());
 
-        return user;
-    }
+			if(user.getRole() == Role.BANNED){
+				log.info("차단된 유저가 로그인 시도 : {}", attributes.getEmail());
+				throw new CustomException(ErrorCode.BANNED_USER_LOGIN);
+			}
 
+			log.info("{} 유저 인식 완료.", attributes.getName());
+		} catch (CustomException e) {
+			throw e;
+		} catch (RuntimeException e) {
+			user = UserConvertor.attributesToUser(attributes);
+			userWriteService.save(user);
+			log.info("{} 유저 최초 로그인.", attributes.getName());
+		}
+
+		return user;
+	}
 }

--- a/src/main/java/com/lion/be/global/config/SecurityConfig.java
+++ b/src/main/java/com/lion/be/global/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -25,6 +26,7 @@ import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -55,6 +57,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers(AuthEndpoints.PERMIT_ALL_PATTERNS).permitAll()
+						.requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 ).oauth2Login(
                         oauth2 -> oauth2

--- a/src/main/java/com/lion/be/global/exception/ErrorCode.java
+++ b/src/main/java/com/lion/be/global/exception/ErrorCode.java
@@ -36,7 +36,7 @@ public enum ErrorCode {
     UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "업로드 중 에러가 발생했습니다."),
 
     TOO_MANY_API_REQUEST_EXCEPTION(HttpStatus.TOO_MANY_REQUESTS, "API 요청 횟수를 초과했습니다."), IMAGE_DELETE_ACCESS_DENIED(
-		HttpStatus.FORBIDDEN,"이미지 소유권자 가 아닙니다." );
+		HttpStatus.FORBIDDEN,"이미지 소유권자 가 아닙니다." ), BANNED_USER_LOGIN(HttpStatus.UNAUTHORIZED,"밴된 유저입니다. " );
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/lion/be/global/filter/JwtAuthFilter.java
+++ b/src/main/java/com/lion/be/global/filter/JwtAuthFilter.java
@@ -37,7 +37,16 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         String token = resolveToken(request);
         if (token != null && jwtTokenProvider.validateToken(token)) {
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+			Authentication authentication = jwtTokenProvider.getAuthentication(token);
+			boolean isBanned = authentication.getAuthorities().stream()
+				.anyMatch(auth -> "ROLE_BANNED".equals(auth.getAuthority()));
+
+			if (isBanned) {
+				response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+				response.setContentType("application/json;charset=UTF-8");
+				response.getWriter().write("{\"error\":\"계정이 정지되었습니다.\"}");
+				return;
+			}
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/src/main/java/com/lion/be/user/domain/entity/User.java
+++ b/src/main/java/com/lion/be/user/domain/entity/User.java
@@ -176,4 +176,7 @@ public class User extends BaseEntity {
 		UserPhoto userPhoto = new UserPhoto(this, image, orderIndex);
 		this.userPhotos.add(userPhoto);
 	}
+	public void updateRole(Role role) {
+		this.role = role;
+	}
 }

--- a/src/test/java/com/lion/be/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/lion/be/acceptance/AcceptanceTest.java
@@ -1,8 +1,6 @@
 package com.lion.be.acceptance;
 
-import static com.lion.be.acceptance.auth.AuthSteps.비회원이_로그인한다;
-import static com.lion.be.acceptance.auth.AuthSteps.원준이_로그인한다;
-import static com.lion.be.acceptance.auth.AuthSteps.토킷이_로그인한다;
+import static com.lion.be.acceptance.auth.AuthSteps.*;
 import static com.lion.be.acceptance.image.ImageSteps.이미지_리스트를_업로드한다;
 import static com.lion.be.acceptance.user.UserSteps.비회원_회원가입;
 import static com.lion.be.acceptance.user.UserSteps.온보딩을_완료한다;
@@ -25,6 +23,7 @@ import io.restassured.specification.RequestSpecification;
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -152,6 +151,7 @@ public abstract class AcceptanceTest {
 
     public String 회원_원준_액세스토큰;
     public String 회원_토킷_액세스토큰;
+	public String 어드민_멋사_액세스토큰;
     public String 비회원_엑세스토큰;
 
     @Autowired
@@ -211,6 +211,7 @@ public abstract class AcceptanceTest {
     private void initAccessToken() {
         회원_원준_액세스토큰 = 원준_액세스토큰_요청();
         회원_토킷_액세스토큰 = 토킷_엑세스토큰_요청();
+		어드민_멋사_액세스토큰 = 어드민_멋사_액세스토큰_요청();
         비회원_엑세스토큰 = 비회원_액세스토큰_요청();
     }
 
@@ -228,6 +229,10 @@ public abstract class AcceptanceTest {
         비회원_회원가입();
         return 비회원이_로그인한다(new RequestSpecBuilder().build()).jsonPath().getString("accessToken");
     }
+
+	private static String 어드민_멋사_액세스토큰_요청() {
+		return 어드민이_로그인한다(new RequestSpecBuilder().build()).jsonPath().getString("accessToken");
+	}
 
     /**
      * 토킷 완전 온보딩 (로그인 → 이미지 리스트 업로드 → 온보딩) - 더 효율적!
@@ -280,4 +285,8 @@ public abstract class AcceptanceTest {
         return accessToken;
     }
 
+	protected static final Map<String, Object> 토킷_사용자의_로그인_정보 = Map.of(
+		"email", "토킷_이메일@example.com",
+		"password", "토킷_비밀번호"
+	);
 }

--- a/src/test/java/com/lion/be/acceptance/admin/AdminAcceptanceTest.java
+++ b/src/test/java/com/lion/be/acceptance/admin/AdminAcceptanceTest.java
@@ -1,0 +1,109 @@
+package com.lion.be.acceptance.admin;
+
+import static com.lion.be.acceptance.admin.AdminSteps.*;
+import static com.lion.be.acceptance.user.UserSteps.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.lion.be.acceptance.AcceptanceTest;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+class AdminAcceptanceTest extends AcceptanceTest {
+
+	@Test
+	@DisplayName("어드민이 사용자를 차단한다")
+	void should_ban_user_when_admin_requests() {
+		api_문서_타이틀("should_ban_user_when_admin_requests",spec);
+		// given
+		String 원준_사용자_EMAIL = 회원_email를_가져온다(spec, 회원_원준_액세스토큰).jsonPath().getString("email");
+		String 차단_사유 = "부적절한 행동으로 인한 차단";
+
+		// when
+		ExtractableResponse<Response> response = 사용자를_차단한다(
+			원준_사용자_EMAIL,
+			차단_사유,
+			어드민_멋사_액세스토큰, // 어드민 토큰
+			spec
+		);
+
+		// then
+		사용자_차단이_성공했는지_검증한다(response, 원준_사용자_EMAIL, 차단_사유);
+	}
+
+	@Test
+	@DisplayName("어드민이 차단된 사용자를 해제한다")
+	void should_unban_user_when_admin_requests() {
+		api_문서_타이틀("should_unban_user_when_admin_requests",spec);
+		// given
+		String 토킷_사용자_EMAIL = 회원_email를_가져온다(spec, 회원_토킷_액세스토큰).jsonPath().getString("email");
+		String 차단_사유 = "부적절한 행동으로 인한 차단";
+		String 해제_사유 = "반성하여 차단 해제";
+
+		// 먼저 사용자를 차단
+		ExtractableResponse<Response> 차단_응답 = 사용자를_차단한다(
+			토킷_사용자_EMAIL,
+			차단_사유,
+			어드민_멋사_액세스토큰, // 어드민 토큰
+			spec
+		);
+
+		사용자_차단이_성공했는지_검증한다(차단_응답, 토킷_사용자_EMAIL, 차단_사유);
+
+		// when
+		ExtractableResponse<Response> 해지_응답 = 사용자_차단을_해제한다(
+			토킷_사용자_EMAIL,
+			해제_사유,
+			어드민_멋사_액세스토큰,// 어드민 토큰사용
+			spec
+		);
+
+		// then
+		사용자_차단_해제가_성공했는지_검증한다(해지_응답, 토킷_사용자_EMAIL, 해제_사유);
+	}
+
+	@Test
+	@DisplayName("일반 사용자가 밴 API에 접근하면 401이다")
+	void should_deny_access_when_regular_user_tries_ban() {
+		api_문서_타이틀("should_deny_access_when_regular_user_tries_ban",spec);
+		// given
+		String 토킷_사용자_EMAIL = 회원_email를_가져온다(spec, 회원_토킷_액세스토큰).jsonPath().getString("email");
+		String 차단_사유 = "부적절한 행동으로 인한 차단";
+
+		// when - 일반 사용자(원준)가 다른 사용자(토킷)를 차단하려고 시도
+		ExtractableResponse<Response> response = 사용자를_차단한다(
+			토킷_사용자_EMAIL,
+			차단_사유,
+			회원_원준_액세스토큰, // 일반 사용자 토큰 사용
+			spec
+		);
+
+		// then
+		권한이_없어서_접근이_거부되었는지_검증한다(response);
+	}
+
+	@Test
+	@DisplayName("일반 사용자가 언밴 API에 접근하면 401이다")
+	void should_deny_access_when_regular_user_tries_unban() {
+		api_문서_타이틀("should_deny_access_when_regular_user_tries_unban",spec);
+		// given
+		String 토킷_사용자_EMAIL = 회원_email를_가져온다(spec, 회원_토킷_액세스토큰).jsonPath().getString("email");
+		String 해제_사유 = "반성하여 차단 해제";
+
+		// 먼저 어드민이 사용자를 차단
+		사용자를_차단한다(토킷_사용자_EMAIL, "차단", 어드민_멋사_액세스토큰, spec);
+
+		// when - 일반 사용자(원준)가 차단 해제를 시도
+		ExtractableResponse<Response> response = 사용자_차단을_해제한다(
+			토킷_사용자_EMAIL,
+			해제_사유,
+			회원_원준_액세스토큰, // 일반 사용자 토큰 사용
+			spec
+		);
+
+		// then
+		권한이_없어서_접근이_거부되었는지_검증한다(response);
+	}
+}

--- a/src/test/java/com/lion/be/acceptance/admin/AdminSteps.java
+++ b/src/test/java/com/lion/be/acceptance/admin/AdminSteps.java
@@ -1,0 +1,92 @@
+package com.lion.be.acceptance.admin;
+
+import static com.lion.be.acceptance.user.UserSteps.상태코드를_검증한다;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+public class AdminSteps {
+
+	public static ExtractableResponse<Response> 사용자를_차단한다(
+		String email,
+		String reason,
+		String adminAccessToken,
+		RequestSpecification spec) {
+
+		Map<String, Object> banRequest = Map.of(
+			"email", email,
+			"reason", reason
+		);
+
+		return RestAssured
+			.given()
+			.spec(spec)
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.auth().oauth2(adminAccessToken)
+			.body(banRequest)
+			.log().all()
+			.when()
+			.post("/api/admin/ban")
+			.then()
+			.log().all()
+			.extract();
+	}
+
+	public static ExtractableResponse<Response> 사용자_차단을_해제한다(
+		String email,
+		String reason,
+		String adminAccessToken,
+		RequestSpecification spec) {
+
+		Map<String, Object> unbanRequest = Map.of(
+			"email", email,
+			"reason", reason
+		);
+
+		return RestAssured
+			.given()
+			.spec(spec)
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.auth().oauth2(adminAccessToken)
+			.body(unbanRequest)
+			.log().all()
+			.when()
+			.patch("/api/admin/unban")
+			.then()
+			.log().all()
+			.extract();
+	}
+
+	public static void 사용자_차단이_성공했는지_검증한다(ExtractableResponse<Response> response, String email, String reason) {
+		Assertions.assertAll(
+			() -> 상태코드를_검증한다(response, HttpStatus.OK),
+			() -> assertThat(response.jsonPath().getString("bannedUserEmail")).isEqualTo(email),
+			() -> assertThat(response.jsonPath().getString("role")).isEqualTo("BANNED"),
+			() -> assertThat(response.jsonPath().getString("reason")).isEqualTo(reason),
+			() -> assertThat(response.jsonPath().getString("message")).isEqualTo("사용자 정지를 성공하였습니다."),
+			() -> assertThat(response.jsonPath().getString("bannedAt")).isNotNull()
+		);
+	}
+
+	public static void 사용자_차단_해제가_성공했는지_검증한다(ExtractableResponse<Response> response, String email, String reason) {
+		Assertions.assertAll(
+			() -> 상태코드를_검증한다(response, HttpStatus.OK),
+			() -> assertThat(response.jsonPath().getString("unbanUserEmail")).isEqualTo(email),
+			() -> assertThat(response.jsonPath().getString("role")).isEqualTo("USER"),
+			() -> assertThat(response.jsonPath().getString("reason")).isEqualTo(reason),
+			() -> assertThat(response.jsonPath().getString("message")).isEqualTo("사용자 해지를 성공하였습니다."),
+			() -> assertThat(response.jsonPath().getString("unbanAt")).isNotNull()
+		);
+	}
+
+	public static void 권한이_없어서_접근이_거부되었는지_검증한다(ExtractableResponse<Response> response) {
+		상태코드를_검증한다(response, HttpStatus.UNAUTHORIZED);
+	}
+}

--- a/src/test/java/com/lion/be/acceptance/auth/AuthSteps.java
+++ b/src/test/java/com/lion/be/acceptance/auth/AuthSteps.java
@@ -23,6 +23,10 @@ public class AuthSteps {
 		return 로그인한다(AuthFixture.사용자_토킷_로그인_요청(), spec);
 	}
 
+	public static ExtractableResponse<Response> 어드민이_로그인한다(RequestSpecification spec) {
+		return 로그인한다(AuthFixture.어드민_멋사_로그인_요청(), spec);
+	}
+
     public static ExtractableResponse<Response> 비회원이_로그인한다(RequestSpecification spec) {
         return 로그인한다(AuthFixture.비회원_로그인_요청(), spec);
     }

--- a/src/test/java/com/lion/be/acceptance/user/UserSteps.java
+++ b/src/test/java/com/lion/be/acceptance/user/UserSteps.java
@@ -42,6 +42,18 @@ public class UserSteps {
                 .extract();
     }
 
+	public static ExtractableResponse<Response> 회원_email를_가져온다(RequestSpecification spec, String accessToken) {
+		return RestAssured
+			.given()
+			.spec(spec)
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.auth().oauth2(accessToken)
+			.when()
+			.get("/api/users/me")
+			.then()
+			.extract();
+	}
+
     public static ExtractableResponse<Response> 온보딩을_완료한다(
         Map<String, Object> onboardingRequest,
         String accessToken,

--- a/src/test/java/com/lion/be/acceptance/util/AuthFixture.java
+++ b/src/test/java/com/lion/be/acceptance/util/AuthFixture.java
@@ -27,4 +27,11 @@ public class AuthFixture {
 			"imageUrl", 회원_토킷.getImageUrl());
 	}
 
+	public static Map<String, Object> 어드민_멋사_로그인_요청() {
+		return Map.of(
+			"email", 어드민_멋사.getEmail(),
+			"name", 어드민_멋사.getName(),
+			"imageUrl", 어드민_멋사.getImageUrl());
+	}
+
 }

--- a/src/test/java/com/lion/be/acceptance/util/UserFixture.java
+++ b/src/test/java/com/lion/be/acceptance/util/UserFixture.java
@@ -13,6 +13,7 @@ public enum UserFixture {
 
     회원_원준("wj1234@gmail.com", "정원준", "https://www", false),
 	회원_토킷("tokit@gmail.com", "김토킷", "https://www", false),
+	어드민_멋사("admin@gmail.com", "어드민", "https://www", true),
 	비회원("asd1234@naver.com", "성이름", "https://www", false);
 
     private String email;

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -35,8 +35,8 @@ VALUES
     (19, '이웹개발', '즐거운개발자', 'web1@test.com', 'https://test.com/image17.jpg', 'USER', 'WOMEN', 'DONGDUK', 'FRONTEND', 'ESFP', 'COMPLETED', '즐겁게 웹 개발하는 개발자', true, 3, 'PREFERENCE_FOCUSED', NOW(), NOW()),
     (20, '박멀티', '융합개발자', 'multi1@test.com', 'https://test.com/image18.jpg', 'USER', 'MEN', 'SOOKMYUNG', 'FULLSTACK', 'ESFJ', 'COMPLETED', '다양한 기술을 융합하는 개발자', true, 3, 'POSITION_FOCUSED', NOW(), NOW()),
     (21, '최리더', '액션리더', 'leader1@test.com', 'https://test.com/image19.jpg', 'USER', 'WOMEN', 'EWHA', 'PM', 'ESTP', 'COMPLETED', '액션형 프로젝트 리더', false, 3, 'PREFERENCE_FOCUSED', NOW(), NOW()),
-    (22, '정올인원', '효율개발자', 'all1@test.com', 'https://test.com/image20.jpg', 'USER', 'MEN', 'SEOUL', 'FULLSTACK', 'ISTP', 'COMPLETED', '실용적이고 효율적인 개발을 추구합니다', true, 3, 'CAREER_FOCUSED', NOW(), NOW());
-
+    (22, '정올인원', '효율개발자', 'all1@test.com', 'https://test.com/image20.jpg', 'USER', 'MEN', 'SEOUL', 'FULLSTACK', 'ISTP', 'COMPLETED', '실용적이고 효율적인 개발을 추구합니다', true, 3, 'CAREER_FOCUSED', NOW(), NOW()),
+    (23, '어드민', '어드민','admin@gmail.com', 'https://www', 'ADMIN', 'MEN', 'SEOUL', 'FULLSTACK', 'ISTP', 'COMPLETED',  '실용적이고 효율적인 개발을 추구합니다', true, 3, 'CAREER_FOCUSED', NOW(), NOW());
 -- === 더미 유저용 이미지 데이터 (각 유저마다 최소 1장 이상) ===
 INSERT INTO image (id, original_file_name, stored_file_name, image_url, uploader_id, is_deleted, created_at, updated_at)
 VALUES
@@ -77,7 +77,8 @@ VALUES
     (30, 'multi1-1.jpg', 'uuid30_multi1-1.jpg', 'https://test.com/photo18-1.jpg', 20, false, NOW(), NOW()),
     (31, 'leader1-1.jpg', 'uuid31_leader1-1.jpg', 'https://test.com/photo19-1.jpg', 21, false, NOW(), NOW()),
     (32, 'all1-1.jpg', 'uuid32_all1-1.jpg', 'https://test.com/photo20-1.jpg', 22, false, NOW(), NOW()),
-    (33, 'all1-2.jpg', 'uuid33_all1-2.jpg', 'https://test.com/photo20-2.jpg', 22, false, NOW(), NOW());
+    (33, 'all1-2.jpg', 'uuid33_all1-2.jpg', 'https://test.com/photo20-2.jpg', 22, false, NOW(), NOW()),
+    (34, 'admin-3.jpg', 'admin-2.jpg', 'https://test.com/admin-2.jpg', 23, false, NOW(), NOW());
 
 -- === UserPhoto 중간 테이블 데이터 (온보딩 완료한 사용자들만) ===
 INSERT INTO user_photo (user_id, image_id, order_index, created_at, updated_at)
@@ -119,7 +120,8 @@ VALUES
     (20, 30, 1, NOW(), NOW()), -- 박멀티
     (21, 31, 1, NOW(), NOW()), -- 최리더
     (22, 32, 1, NOW(), NOW()), -- 정올인원
-    (22, 33, 2, NOW(), NOW());
+    (22, 33, 2, NOW(), NOW()),
+    (23, 34, 1, NOW(), NOW()); -- 어드민
 
 -- === 약관 동의 데이터 (온보딩 완료한 사용자들만) ===
 INSERT INTO agreements (user_id, agreement_type, agreed)
@@ -168,4 +170,6 @@ VALUES
     (21, 'REQUIRED', true),  -- 최리더
     (21, 'MARKETING', true),
     (22, 'REQUIRED', true),  -- 정올인원
-    (22, 'MARKETING', false);
+    (22, 'MARKETING', false),
+    (23, 'REQUIRED', true),  -- 어드민
+    (23, 'MARKETING', false);


### PR DESCRIPTION
### 주요 기능

#### 1. **관리자 벤 관리**
- ✅ 관리자가 이메일로 유저 벤 처리
- ✅ 관리자가 벤 해제 가능
- ✅ 비관리자 접근 시 401 에러 반환

#### 2. **벤 유저 제한사항**
- ✅ 차단된 유저는 새로운 토큰 발급 불가 (로그인 차단)
- ✅ 기존 액세스 토큰이 유효한 동안에는 앱 사용 가능
- ✅ 토큰 만료 후에는 재로그인 불가

## 🔒 Feat: 유저 벤 시스템 구현

### 📋 변경사항
- 관리자 전용 유저 벤/언벤 API 구현
- 이메일 기반 벤 처리 시스템
- 벤 유저 토큰 발급 제한
- 권한 체크 미들웨어 추가

### 🚀 주요 기능

#### 관리자 기능
- `POST /admin/users/ban` - 유저 벤 처리
- `POST /admin/users/unban` - 유저 벤 해제
- 이메일을 통한 대상 유저 식별

#### 보안 강화
- 비관리자 접근 시 401 Unauthorized 응답
- 벤 유저 로그인/토큰 재발급 차단
- 기존 토큰은 만료까지 유효 (점진적 차단)

### 🔧 기술적 구현

벤처리

request

```json
POST /admin/users/ban
{
  "reason" : "부적절한 행동으로 인한 차단",
  "email" : "wj1234@gmail.com"
}
```

response

```json
{
  "message" : "사용자 정지를 성공하였습니다.",
  "bannedUserId" : 1,
  "bannedUserEmail" : "wj1234@gmail.com",
  "reason" : "부적절한 행동으로 인한 차단",
  "role" : "BANNED",
  "bannedAt" : "2025-08-14T00:07:40.254241"
}
```

벤 해제

request

```json
POST /admin/users/unban
{
  "reason" : "반성하여 차단 해제",
  "email" : "tokit@gmail.com"
}
```

response

```json
{
  "message" : "사용자 해지를 성공하였습니다.",
  "unbanUserId" : 2,
  "unbanUserEmail" : "tokit@gmail.com",
  "reason" : "반성하여 차단 해제",
  "role" : "USER",
  "unbanAt" : "2025-08-14T00:07:41.037529"
}
```
